### PR TITLE
fix: reset frame counter when reading speed on video loop true value

### DIFF
--- a/VisionPilot/modules/sensing/vehicle_interface/include/vehicle_interface/file_interface.hpp
+++ b/VisionPilot/modules/sensing/vehicle_interface/include/vehicle_interface/file_interface.hpp
@@ -8,7 +8,7 @@
 class FileInterface : public VehicleInterface
 {
 public:
-    FileInterface(const std::string& filename);
+    FileInterface(const std::string& filename, bool loop);
     ~FileInterface() override = default;
 
     // Read vehicle speed via CAN frame
@@ -18,6 +18,7 @@ public:
     void write(double steering, double acceleration) override;
 
 private:
+    bool loop_;
     std::vector<double> speeds_;
     int frame_cnt_ = 0;
 };

--- a/VisionPilot/modules/sensing/vehicle_interface/src/file_interface.cpp
+++ b/VisionPilot/modules/sensing/vehicle_interface/src/file_interface.cpp
@@ -3,7 +3,7 @@
 #include <fstream>
 #include <vehicle_interface/file_interface.hpp>
 
-FileInterface::FileInterface(const std::string& filename)
+FileInterface::FileInterface(const std::string& filename, bool loop) : loop_(loop)
 {
     std::ifstream file(filename);
     if (file.is_open())
@@ -41,7 +41,14 @@ double FileInterface::read()
 
     if (frame_cnt_ >= speeds_.size())
     {
-        throw std::runtime_error("FileInterface: read() called past end of speeds data");
+        if (loop_)
+        {
+            frame_cnt_ = 0;
+        }
+        else
+        {
+            throw std::runtime_error("FileInterface: read() called past end of speeds data");
+        }
     }
 
     return speeds_[frame_cnt_++];


### PR DESCRIPTION
When loop configuration value for video is set to try, speed values reader was not resetting the counter to 0.